### PR TITLE
Notifications based on weekly and monthly budget values

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/progprof/bargainmargintemplate/ui/BudgetNotificationManager.kt
+++ b/app/src/main/java/com/progprof/bargainmargintemplate/ui/BudgetNotificationManager.kt
@@ -1,0 +1,56 @@
+package com.progprof.bargainmargintemplate.ui
+
+import android.Manifest
+import android.R
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+
+object BudgetNotificationManager {
+
+    private const val CHANNEL_ID = "budget_alerts_channel"
+    private const val CHANNEL_NAME = "Budget Alerts"
+    private const val CHANNEL_DESC = "Notifications triggered when your budget gets low"
+
+    fun createNotificationChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply { description = CHANNEL_DESC }
+
+            val manager = context.getSystemService(NotificationManager::class.java)
+            manager?.createNotificationChannel(channel)
+        }
+    }
+
+    fun sendNotification(context: Context, title: String, message: String) {
+
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val permission = Manifest.permission.POST_NOTIFICATIONS
+            if (context.checkSelfPermission(permission) != PackageManager.PERMISSION_GRANTED) {
+                return  // prevent crash if permission is not granted
+            }
+        }
+
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_dialog_info) // temporary icon
+            .setContentTitle(title)
+            .setContentText(message)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+
+        with(NotificationManagerCompat.from(context)) {
+            notify(System.currentTimeMillis().toInt(), builder.build())
+        }
+    }
+}
+
+
+

--- a/app/src/main/java/com/progprof/bargainmargintemplate/ui/BudgetViewModel.kt
+++ b/app/src/main/java/com/progprof/bargainmargintemplate/ui/BudgetViewModel.kt
@@ -28,6 +28,8 @@ data class Category(
 
 class BudgetViewModel(application: Application) : AndroidViewModel(application) {
 
+    private val appContext = getApplication<Application>().applicationContext
+
     private val db by lazy {
         Room.databaseBuilder(
             application.applicationContext,
@@ -125,6 +127,44 @@ class BudgetViewModel(application: Application) : AndroidViewModel(application) 
                 week4RemainingBudget = if (week == 4) currentBudget.week4RemainingBudget - amount else currentBudget.week4RemainingBudget
             )
             repository.updateBudget(updatedBudget)
+            checkAndNotifyBudget(updatedBudget, week)
+        }
+    }
+
+    private fun checkAndNotifyBudget(budget: BudgetEntity, week: Int) {
+
+        val monthlyPercentRemaining = budget.monthlyRemainingBudget / budget.totalBudget
+
+        if (monthlyPercentRemaining <= 0.25) {
+            BudgetNotificationManager.sendNotification(
+                appContext,
+                "Monthly Budget Alert",
+                "You've used 75% of your monthly budget."
+            )
+        }
+
+        val weeklyRemaining = when (week) {
+            1 -> budget.week1RemainingBudget
+            2 -> budget.week2RemainingBudget
+            3 -> budget.week3RemainingBudget
+            else -> budget.week4RemainingBudget
+        }
+
+        val weeklyTotal = when (week) {
+            1 -> budget.week1TotalBudget
+            2 -> budget.week2TotalBudget
+            3 -> budget.week3TotalBudget
+            else -> budget.week4TotalBudget
+        }
+
+        val weeklyPercentRemaining = weeklyRemaining / weeklyTotal
+
+        if (weeklyPercentRemaining <= 0.25) {
+            BudgetNotificationManager.sendNotification(
+                appContext,
+                "Weekly Budget Alert",
+                "You've used 75% of your Week $week budget."
+            )
         }
     }
 


### PR DESCRIPTION
Must clear app data beforehand to receive permissions request.
Notifications are triggered when the monthly or weekly budgets fall below 25%
 